### PR TITLE
[Fix] black not supported for py39

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 100
-target-version = ['py36', 'py37', 'py38', 'py39']
+target-version = ['py36', 'py37', 'py38']
 include = '\.pyi?$'
 extend-exclude = '''
 /(


### PR DESCRIPTION
Fixes error:
```
Error: Invalid value for '-t' / '--target-version': invalid choice: py39. (choose from py27, py33, py34, py35, py36, py37, py38)
```