### PR TITLE
Robust get_next_num_run

### DIFF
--- a/common/utils/backend.py
+++ b/common/utils/backend.py
@@ -1,6 +1,7 @@
 import glob
 import os
 import pickle
+import re
 import shutil
 import tempfile
 import time
@@ -357,6 +358,7 @@ class Backend(object):
         other_num_runs = [
             int(os.path.basename(run_dir).split("_")[1])
             for run_dir in glob.glob(os.path.join(self.internals_directory, "runs", "*"))
+            if re.match(r"\d+_\d+_\d+", os.path.basename(run_dir))
         ]
         if len(other_num_runs) > 0:
             # We track the number of runs from two forefronts:

--- a/common/utils/backend.py
+++ b/common/utils/backend.py
@@ -384,7 +384,7 @@ class Backend(object):
 
         Returns
         -------
-        bool:
+        _: bool
             whether the provided run directory matches the run_dir_pattern
             signifying that it is a run directory
         """

--- a/common/utils/backend.py
+++ b/common/utils/backend.py
@@ -358,7 +358,7 @@ class Backend(object):
         other_num_runs = [
             int(os.path.basename(run_dir).split("_")[1])
             for run_dir in glob.glob(os.path.join(self.internals_directory, "runs", "*"))
-            if re.match(r"\d+_\d+_\d+", os.path.basename(run_dir))
+            if self._is_run_dir(os.path.basename(run_dir))
         ]
         if len(other_num_runs) > 0:
             # We track the number of runs from two forefronts:
@@ -371,6 +371,25 @@ class Backend(object):
         if not peek:
             self.active_num_run += 1
         return self.active_num_run
+
+    @staticmethod
+    def _is_run_dir(run_dir: str) -> bool:
+        """
+        Run directories are stored in the format <seed>_<num_run>_<budget>.
+
+        Parameters
+        ----------
+        run_dir: str
+            string containing the base name of the run directory
+
+        Returns
+        -------
+        bool:
+            whether the provided run directory matches the run_dir_pattern
+            signifying that it is a run directory
+        """
+        run_dir_pattern = r"\d+_\d+_\d+"
+        return bool(re.match(run_dir_pattern, run_dir))
 
     def get_model_filename(self, seed: int, idx: int, budget: float) -> str:
         return "%s.%s.%s.model" % (seed, idx, budget)


### PR DESCRIPTION
The current implementation of `get_next_num_run` assumes that only run directories of the format `<seed>_<num_run>_<budget>` are present in `runs/`. However, sometimes the temp directories are not able to be renamed in that particular format and the function crashes. More specifically, if there is a folder in `runs/` of the name `'tmp342'`, the current implementation crashes. This PR aims to robustify this by matching a regular expression to only pick directories that fulfil the pattern