### PR TITLE
Set exist_ok = True while creating the backend

### DIFF
--- a/common/utils/backend.py
+++ b/common/utils/backend.py
@@ -118,13 +118,14 @@ class BackendContext(object):
         return os.path.expanduser(os.path.expandvars(self._temporary_directory))
 
     def create_directories(self) -> None:
-        # Exception is raised if self.temporary_directory already exists.
-        os.makedirs(self.temporary_directory)
+        # No Exception is raised if self.temporary_directory already exists.
+        # This allows to continue the search, also, an error will be raised if
+        # save_start_time is called which ensures two searches are not performed
+        os.makedirs(self.temporary_directory, exist_ok=True)
         self._tmp_dir_created = True
 
-        # Exception is raised if self.output_directory already exists.
         if self.output_directory is not None:
-            os.makedirs(self.output_directory)
+            os.makedirs(self.output_directory, exist_ok=True)
             self._output_dir_created = True
 
     def delete_directories(self, force: bool = True) -> None:

--- a/common/utils/backend.py
+++ b/common/utils/backend.py
@@ -117,15 +117,15 @@ class BackendContext(object):
         # make sure that tilde does not appear on the path.
         return os.path.expanduser(os.path.expandvars(self._temporary_directory))
 
-    def create_directories(self) -> None:
+    def create_directories(self, exist_ok: bool = False) -> None:
         # No Exception is raised if self.temporary_directory already exists.
         # This allows to continue the search, also, an error will be raised if
         # save_start_time is called which ensures two searches are not performed
-        os.makedirs(self.temporary_directory, exist_ok=True)
+        os.makedirs(self.temporary_directory, exist_ok=exist_ok)
         self._tmp_dir_created = True
 
         if self.output_directory is not None:
-            os.makedirs(self.output_directory, exist_ok=True)
+            os.makedirs(self.output_directory, exist_ok=exist_ok)
             self._output_dir_created = True
 
     def delete_directories(self, force: bool = True) -> None:


### PR DESCRIPTION
We would like to add a feature to continue search in autoPyTorch. For this to function, we need to be able to create a backend without an error being raised, which is done [here](https://github.com/automl/automl_common/blob/93984e17464a2e9078d3b415528f06784515001e/common/utils/backend.py#L122). This PR aims to remove this bottleneck. Still, an error will be raised if the user attempts to call search again, see [here](https://github.com/automl/automl_common/blob/93984e17464a2e9078d3b415528f06784515001e/common/utils/backend.py#L245). 