### PR TITLE
[hotfix] Add conversational function to ask the handling of tmp directory

### DIFF
--- a/common/utils/backend.py
+++ b/common/utils/backend.py
@@ -26,15 +26,21 @@ PIPELINE_IDENTIFIER_TYPE = Tuple[int, int, float]
 
 
 class pycolor:
-    RED = '\033[31m'
-    YELLOW = '\033[33m'
+    color_dict = {
+        'red': '\033[31m',
+        'yellow': '\033[33m'
+    }
     END = '\033[0m'
+
+    @classmethod
+    def print(cls, txt: str, color: str = 'red') -> None:
+        print(f'{cls.color_dict[color]}{txt}{cls.END}')
 
 
 def _ask_delete_existing(dir_name: str, purpose: str) -> None:
     while True:
         print(f'The {purpose} directory `{dir_name}` already exists.')
-        print(pycolor.RED + 'Would you like to delete it and continue?: [y/n/help]\n' + pycolor.END)
+        pycolor.print('Would you like to delete it and continue?: [y/n/help]\n')
         answer = input()
         if answer == 'y':
             print('Delete the directory and continue the process.')

--- a/common/utils/backend.py
+++ b/common/utils/backend.py
@@ -26,38 +26,46 @@ PIPELINE_IDENTIFIER_TYPE = Tuple[int, int, float]
 
 
 class pycolor:
-    color_dict = {
-        'red': '\033[31m',
-        'yellow': '\033[33m'
-    }
-    END = '\033[0m'
+    COLORS = dict(
+        BLACK="\033[30m",
+        RED="\033[31m",
+        GREEN="\033[32m",
+        YELLOW="\033[33m",
+        BLUE="\033[34m",
+        MAGENTA="\033[35m",
+        CYAN="\033[36m",
+        WHITE="\033[37m",
+    )
+    END = "\033[0m"
 
     @classmethod
-    def out(cls, txt: str, color: str = 'red') -> None:
-        if color not in cls.color_dict.keys():
-            raise ValueError('color must be {}, but got {}.'.format(
-                list(cls.color_dict.keys()),
-                color
-            ))
-
-        print(f'{cls.color_dict[color]}{txt}{cls.END}')
+    def print_(cls, txt: str, color="red") -> None:
+        try:
+            col = cls.COLORS[color.upper()]
+            print(f"{col}{txt}{cls.END}")
+        except KeyError:
+            raise ValueError(
+                "color must be in {}, but got {}.".format(
+                    ", ".join(cls.COLORS.keys()), color.upper()
+                )
+            )
 
 
 def _ask_delete_existing(dir_name: str, purpose: str) -> None:
     while True:
-        print(f'The {purpose} directory `{dir_name}` already exists.')
-        pycolor.out('Would you like to delete it and continue?: [y/n/help]\n')
+        print(f"The {purpose} directory `{dir_name}` already exists.")
+        pycolor.print_("Would you like to delete it and continue?: [y/n/help]\n")
         answer = input()
-        if answer == 'y':
-            print('Delete the directory and continue the process.')
+        if answer == "y":
+            print("Delete the directory and continue the process.")
             shutil.rmtree(dir_name)
             return
-        elif answer == 'n':
-            print(f'Change the path for `{purpose}` and try again.')
-            print('Process finished.')
+        elif answer == "n":
+            print(f"Change the path for `{purpose}` and try again.")
+            print("Process finished.")
             sys.exit()
-        elif answer == 'help':
-            print('y: Delete the directory\nn: Finish the process\n')
+        elif answer == "help":
+            print("y: Delete the directory\nn: Finish the process\n")
 
 
 def create(
@@ -155,14 +163,14 @@ class BackendContext(object):
 
     def create_directories(self) -> None:
         if os.path.exists(self.temporary_directory):
-            _ask_delete_existing(self.temporary_directory, purpose='temporary')
+            _ask_delete_existing(self.temporary_directory, purpose="temporary")
 
         os.makedirs(self.temporary_directory)
         self._tmp_dir_created = True
 
         if self.output_directory is not None:
             if os.path.exists(self.output_directory):
-                _ask_delete_existing(self.output_directory, purpose='output')
+                _ask_delete_existing(self.output_directory, purpose="output")
 
             os.makedirs(self.output_directory)
             self._output_dir_created = True

--- a/common/utils/backend.py
+++ b/common/utils/backend.py
@@ -26,16 +26,7 @@ PIPELINE_IDENTIFIER_TYPE = Tuple[int, int, float]
 
 
 class pycolor:
-    COLORS = dict(
-        BLACK="\033[30m",
-        RED="\033[31m",
-        GREEN="\033[32m",
-        YELLOW="\033[33m",
-        BLUE="\033[34m",
-        MAGENTA="\033[35m",
-        CYAN="\033[36m",
-        WHITE="\033[37m",
-    )
+    COLORS = {"RED": "\033[31m", "YELLOW": "\033[33m"}
     END = "\033[0m"
 
     @classmethod

--- a/common/utils/backend.py
+++ b/common/utils/backend.py
@@ -30,7 +30,7 @@ class pycolor:
     END = "\033[0m"
 
     @classmethod
-    def print_(cls, txt: str, color="red") -> None:
+    def print_(cls, txt: str, color: str = "red") -> None:
         try:
             col = cls.COLORS[color.upper()]
             print(f"{col}{txt}{cls.END}")

--- a/common/utils/backend.py
+++ b/common/utils/backend.py
@@ -33,14 +33,20 @@ class pycolor:
     END = '\033[0m'
 
     @classmethod
-    def print(cls, txt: str, color: str = 'red') -> None:
+    def out(cls, txt: str, color: str = 'red') -> None:
+        if color not in cls.color_dict.keys():
+            raise ValueError('color must be {}, but got {}.'.format(
+                list(cls.color_dict.keys()),
+                color
+            ))
+
         print(f'{cls.color_dict[color]}{txt}{cls.END}')
 
 
 def _ask_delete_existing(dir_name: str, purpose: str) -> None:
     while True:
         print(f'The {purpose} directory `{dir_name}` already exists.')
-        pycolor.print('Would you like to delete it and continue?: [y/n/help]\n')
+        pycolor.out('Would you like to delete it and continue?: [y/n/help]\n')
         answer = input()
         if answer == 'y':
             print('Delete the directory and continue the process.')


### PR DESCRIPTION
Currently, we get an error when we already have the tmp or output directory:

```
Traceback (most recent call last):
  File "/home/shuhei/anaconda3/envs/auto-pytorch3.8/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/shuhei/anaconda3/envs/auto-pytorch3.8/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/shuhei/HiwiRepositories/Auto-PyTorch/examples/20_basics/example_tabular_classification.py", line 40, in <module>
    api = TabularClassificationTask(
  File "/home/shuhei/HiwiRepositories/Auto-PyTorch/autoPyTorch/api/tabular_classification.py", line 82, in __init__
    super().__init__(
  File "/home/shuhei/HiwiRepositories/Auto-PyTorch/autoPyTorch/api/base_task.py", line 165, in __init__
    self._backend = create(
  File "/home/shuhei/HiwiRepositories/Auto-PyTorch/autoPyTorch/automl_common/common/utils/backend.py", line 34, in create
    context = BackendContext(
  File "/home/shuhei/HiwiRepositories/Auto-PyTorch/autoPyTorch/automl_common/common/utils/backend.py", line 99, in __init__
    self.create_directories()
  File "/home/shuhei/HiwiRepositories/Auto-PyTorch/autoPyTorch/automl_common/common/utils/backend.py", line 122, in create_directories
    os.makedirs(self.temporary_directory)
  File "/home/shuhei/anaconda3/envs/auto-pytorch3.8/lib/python3.8/os.py", line 223, in makedirs
    mkdir(name, mode)
FileExistsError: [Errno 17] File exists: './tmp/autoPyTorch_example_tmp_01'
```

To avoid this issue, I added a function to ask how to handle the directory.
```
The temporary directory `./tmp/autoPyTorch_example_tmp_01` already exists.
Would you like to delete it and continue?: [y/n/help]

y
Delete the directory and continue the process.

The temporary directory `./tmp/autoPyTorch_example_tmp_01` already exists.
Would you like to delete it and continue?: [y/n/help]

n
Change the path for `temporary` and try again.
Process finished.
```