### PR TITLE
[feat] Add setup.py for the submodule usage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
     long_description = f.read()
 
 requirements = []
-with open('requirements.txt', 'r') as f:
+with open("requirements.txt", "r") as f:
     for line in f:
         requirements.append(line.strip())
 
@@ -17,12 +17,12 @@ setuptools.setup(
     description=("Shared utilities that AutoML frameworks may benefit from."),
     long_description=long_description,
     url="https://github.com/automl/automl_common",
-    license='Apache License 2.0',
+    license="Apache License 2.0",
     keywords="machine learning algorithm configuration hyperparameter "
-             "optimization tuning neural architecture deep learning",
+    "optimization tuning neural architecture deep learning",
     packages=setuptools.find_packages(),
-	python_requires='>=3.7',
-    platforms=['Linux'],
+    python_requires=">=3.7",
+    platforms=["Linux"],
     install_requires=requirements,
-    include_package_data=True
+    include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     name="automl_common",
     version="0.0.1",
     author="AutoML Freiburg",
-    author_email="watanabs@informatik.uni-freiburg.de",
+    author_email="feurerm@informatik.uni-freiburg.de",
     description=("Shared utilities that AutoML frameworks may benefit from."),
     long_description=long_description,
     url="https://github.com/automl/automl_common",

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,28 @@
+import setuptools
+
+
+with open("README.md", "r") as f:
+    long_description = f.read()
+
+requirements = []
+with open('requirements.txt', 'r') as f:
+    for line in f:
+        requirements.append(line.strip())
+
+setuptools.setup(
+    name="automl_common",
+    version="0.0.1",
+    author="AutoML Freiburg",
+    author_email="watanabs@informatik.uni-freiburg.de",
+    description=("Shared utilities that AutoML frameworks may benefit from."),
+    long_description=long_description,
+    url="https://github.com/automl/automl_common",
+    license='Apache License 2.0',
+    keywords="machine learning algorithm configuration hyperparameter "
+             "optimization tuning neural architecture deep learning",
+    packages=setuptools.find_packages(),
+	python_requires='>=3.7',
+    platforms=['Linux'],
+    install_requires=requirements,
+    include_package_data=True
+)


### PR DESCRIPTION
Currently, we get `No module found error` in the package that uses `automl_common` as a submodule. For this reason, we need to add the `setup.py` and each repository, which uses `automl_common` must include the following lines in `setup.py` for the argument of `install_requires`:

```
requirements.append(
    "automl_common "
    "@ git+ssh://git@"
    "github.com/automl/automl_common"
    # "@v0.0.1#egg=automl_common"
    "#egg=automl_common"
)
``` 