### PR TITLE
[ADD] autoPyTorch branch

### DIFF
--- a/common/utils/backend.py
+++ b/common/utils/backend.py
@@ -118,13 +118,14 @@ class BackendContext(object):
         return os.path.expanduser(os.path.expandvars(self._temporary_directory))
 
     def create_directories(self) -> None:
-        # Exception is raised if self.temporary_directory already exists.
-        os.makedirs(self.temporary_directory)
+        # No Exception is raised if self.temporary_directory already exists.
+        # This allows to continue the search, also, an error will be raised if
+        # save_start_time is called which ensures two searches are not performed
+        os.makedirs(self.temporary_directory, exist_ok=True)
         self._tmp_dir_created = True
 
-        # Exception is raised if self.output_directory already exists.
         if self.output_directory is not None:
-            os.makedirs(self.output_directory)
+            os.makedirs(self.output_directory, exist_ok=True)
             self._output_dir_created = True
 
     def delete_directories(self, force: bool = True) -> None:

--- a/common/utils/backend.py
+++ b/common/utils/backend.py
@@ -1,6 +1,7 @@
 import glob
 import os
 import pickle
+import re
 import shutil
 import tempfile
 import time
@@ -358,6 +359,7 @@ class Backend(object):
         other_num_runs = [
             int(os.path.basename(run_dir).split("_")[1])
             for run_dir in glob.glob(os.path.join(self.internals_directory, "runs", "*"))
+            if self._is_run_dir(os.path.basename(run_dir))
         ]
         if len(other_num_runs) > 0:
             # We track the number of runs from two forefronts:
@@ -370,6 +372,25 @@ class Backend(object):
         if not peek:
             self.active_num_run += 1
         return self.active_num_run
+
+    @staticmethod
+    def _is_run_dir(run_dir: str) -> bool:
+        """
+        Run directories are stored in the format <seed>_<num_run>_<budget>.
+
+        Parameters
+        ----------
+        run_dir: str
+            string containing the base name of the run directory
+
+        Returns
+        -------
+        _: bool
+            whether the provided run directory matches the run_dir_pattern
+            signifying that it is a run directory
+        """
+        run_dir_pattern = r"\d+_\d+_\d+"
+        return bool(re.match(run_dir_pattern, run_dir))
 
     def get_model_filename(self, seed: int, idx: int, budget: float) -> str:
         return "%s.%s.%s.model" % (seed, idx, budget)

--- a/common/utils/backend.py
+++ b/common/utils/backend.py
@@ -117,15 +117,15 @@ class BackendContext(object):
         # make sure that tilde does not appear on the path.
         return os.path.expanduser(os.path.expandvars(self._temporary_directory))
 
-    def create_directories(self) -> None:
+    def create_directories(self, exist_ok: bool = False) -> None:
         # No Exception is raised if self.temporary_directory already exists.
         # This allows to continue the search, also, an error will be raised if
         # save_start_time is called which ensures two searches are not performed
-        os.makedirs(self.temporary_directory, exist_ok=True)
+        os.makedirs(self.temporary_directory, exist_ok=exist_ok)
         self._tmp_dir_created = True
 
         if self.output_directory is not None:
-            os.makedirs(self.output_directory, exist_ok=True)
+            os.makedirs(self.output_directory, exist_ok=exist_ok)
             self._output_dir_created = True
 
     def delete_directories(self, force: bool = True) -> None:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
     long_description = f.read()
 
 requirements = []
-with open('requirements.txt', 'r') as f:
+with open("requirements.txt", "r") as f:
     for line in f:
         requirements.append(line.strip())
 
@@ -17,12 +17,12 @@ setuptools.setup(
     description=("Shared utilities that AutoML frameworks may benefit from."),
     long_description=long_description,
     url="https://github.com/automl/automl_common",
-    license='Apache License 2.0',
+    license="Apache License 2.0",
     keywords="machine learning algorithm configuration hyperparameter "
-             "optimization tuning neural architecture deep learning",
+    "optimization tuning neural architecture deep learning",
     packages=setuptools.find_packages(),
-	python_requires='>=3.7',
-    platforms=['Linux'],
+    python_requires=">=3.7",
+    platforms=["Linux"],
     install_requires=requirements,
-    include_package_data=True
+    include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     name="automl_common",
     version="0.0.1",
     author="AutoML Freiburg",
-    author_email="watanabs@informatik.uni-freiburg.de",
+    author_email="feurerm@informatik.uni-freiburg.de",
     description=("Shared utilities that AutoML frameworks may benefit from."),
     long_description=long_description,
     url="https://github.com/automl/automl_common",

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,28 @@
+import setuptools
+
+
+with open("README.md", "r") as f:
+    long_description = f.read()
+
+requirements = []
+with open('requirements.txt', 'r') as f:
+    for line in f:
+        requirements.append(line.strip())
+
+setuptools.setup(
+    name="automl_common",
+    version="0.0.1",
+    author="AutoML Freiburg",
+    author_email="watanabs@informatik.uni-freiburg.de",
+    description=("Shared utilities that AutoML frameworks may benefit from."),
+    long_description=long_description,
+    url="https://github.com/automl/automl_common",
+    license='Apache License 2.0',
+    keywords="machine learning algorithm configuration hyperparameter "
+             "optimization tuning neural architecture deep learning",
+    packages=setuptools.find_packages(),
+	python_requires='>=3.7',
+    platforms=['Linux'],
+    install_requires=requirements,
+    include_package_data=True
+)


### PR DESCRIPTION
This PR includes the fixes and improvements made to the `autoPyTorch` branch. They are listed below:

1.  PR #5 - The current implementation of `get_next_num_run` assumes that only run directories of the format <seed>_<num_run>_<budget> are present in runs/. However, sometimes the temp directories are not able to be renamed in that particular format and the function crashes. More specifically, if there is a folder in runs/ of the name 'tmp342', the current implementation crashes. This PR aims to robustify this by matching a regular expression to only pick directories that fulfil the pattern
2. PR #6 - We would like to add a feature to continue search in autoPyTorch. For this to function, we need to be able to create a backend without an error being raised, which is done [here](https://github.com/automl/automl_common/blob/93984e17464a2e9078d3b415528f06784515001e/common/utils/backend.py#L122). This PR aims to remove this bottleneck. Still, an error will be raised if the user attempts to call search again, see [here](https://github.com/automl/automl_common/blob/93984e17464a2e9078d3b415528f06784515001e/common/utils/backend.py#L245). 
3. PR #9  - Currently, we get `No module found error` in the package that uses `automl_common` as a submodule. For this reason, we need to add the `setup.py` and each repository, which uses `automl_common` must include the following lines in `setup.py` for the argument of `dependency_links`:

```
dependency_links=['https://github.com/automl/automl_common.git/tarball/<branch>#egg=package-<version>']
``` 